### PR TITLE
Refs #17: Refactor kwargs for load to add cross correlation chopper option

### DIFF
--- a/file_handling/load.py
+++ b/file_handling/load.py
@@ -10,7 +10,7 @@ def load(ws_name, input_files, geometry=None, chemical_formula=None, mass_densit
 
     # In order to preserve pulse information
     if 'CorrelationChopper' in kwargs:
-        align_and_focus_args['CompressWallClockTolerance'] = 0.001
+        align_and_focus_args['CompressTolerance'] = 0.0
 
     print(align_and_focus_args)
     AlignAndFocusPowderFromFiles(OutputWorkspace=ws_name,

--- a/file_handling/load.py
+++ b/file_handling/load.py
@@ -1,7 +1,13 @@
-from mantid.simpleapi import AlignAndFocusPowderFromFiles, NormaliseByCurrent, SetSample, ConvertUnits
+from mantid.simpleapi import \
+    AlignAndFocusPowderFromFiles, NormaliseByCurrent, \
+    SetSample, ConvertUnits, CorelliCrossCorrelate
 
 
-def load(ws_name, input_files, geometry=None, chemical_formula=None, mass_density=None, **align_and_focus_args):
+def load(ws_name, input_files, geometry=None, chemical_formula=None, mass_density=None, **kwargs):
+    align_and_focus_args = None
+    if 'AlignAndFocusArgs' in kwargs:
+        align_and_focus_args = kwargs['AlignAndFocusArgs']
+
     AlignAndFocusPowderFromFiles(OutputWorkspace=ws_name,
                                  Filename=input_files,
                                  Absorption=None,
@@ -11,6 +17,13 @@ def load(ws_name, input_files, geometry=None, chemical_formula=None, mass_densit
                        RecalculatePCharge=True)
     if geometry and chemical_formula and mass_density:
         set_sample(ws_name, geometry, chemical_formula, mass_density)
+
+    # Cross-correlation chopper for Corelli
+    if 'CorrelationChoppper' in kwargs:
+        cc_opts = kwargs['CorrelationChopper']
+        CorelliCrossCorrelate(InputWorkspace=ws_name,
+                              OutputWorkspace=ws_name,
+                              TimingOffset=cc_opts['TimingOffset'])
 
     ConvertUnits(InputWorkspace=ws_name,
                  OutputWorkspace=ws_name,

--- a/file_handling/test/test_load.py
+++ b/file_handling/test/test_load.py
@@ -10,7 +10,7 @@ from mantid.simpleapi import mtd
 class TestLoad(unittest.TestCase):
 
     def setUp(self):
-        self.align_and_focus_args = {
+        align_and_focus_args = {
             'CalFilename': os.path.join(ROOT_DIR, 'isis', 'polaris', 'grouping.cal'),
             'ResampleX': -6000,
             'DSpacing': False,
@@ -18,12 +18,15 @@ class TestLoad(unittest.TestCase):
             'MaxChunkSize': 8,
             'ReductionProperties': '__powderreduction'
         }
+
+        self.loadKwargs = {'AlignAndFocusArgs': align_and_focus_args}
+
         # Highly cropped version of the workspace to improve run time
         self.sample_file_path = os.path.join(ROOT_DIR, 'test_data', 'POLARIS00097947-min.nxs')
 
     def test_basic_load(self):
         ws_name = 'test-sample'
-        actual = load(ws_name, self.sample_file_path, **self.align_and_focus_args)
+        actual = load(ws_name, self.sample_file_path, **self.loadKwargs)
         actual = mtd[actual]
         self.assertEqual(actual.name(), ws_name)
         self.assertEqual(actual.getNumberHistograms(), 5)
@@ -43,10 +46,14 @@ class TestLoad(unittest.TestCase):
                       geometry=geometry,
                       chemical_formula=formula,
                       mass_density=mass_density,
-                      **self.align_and_focus_args)
+                      **self.loadKwargs)
         actual = mtd[actual]
         self.assertEqual(actual.sample().getMaterial().name(), 'Si')
         mtd.clear()
+
+    # TODO: Cover the correlation chopper with test.
+    # Need Corelli data uploaded to remote test server first.
+
 
 if __name__ == '__main__':
     unittest.main()  # pragma: no cover

--- a/file_handling/test/test_save.py
+++ b/file_handling/test/test_save.py
@@ -21,10 +21,12 @@ class TestSave(unittest.TestCase):
             'MaxChunkSize': 8,
             'ReductionProperties': '__powderreduction'
         }
+
+        loadKwargs = {'AlignAndFocusArgs': align_and_focus_args}
         # Highly cropped version of the workspace to improve run time
         ws_name = 'test-sample'
         sample_file_path = os.path.join(ROOT_DIR, 'test_data', 'POLARIS00097947-min.nxs')
-        wksp = load(ws_name, sample_file_path, **align_and_focus_args)
+        wksp = load(ws_name, sample_file_path, **loadKwargs)
 
         self.wksp = mtd[wksp]
         self.out_nxs = '%s.nxs' % ws_name

--- a/mantid_total_scattering.py
+++ b/mantid_total_scattering.py
@@ -375,6 +375,10 @@ def main(config=None):
     van_inelastic_corr = SetInelasticCorrection(
         van.get('InelasticCorrection', None))
 
+    # Collect key word arguments for load algorithm
+    loadKwargs = dict()
+
+    # 1. collect AlignAndFocus arguments
     alignAndFocusArgs = dict()
     alignAndFocusArgs['CalFilename'] = config['Calibration']['Filename']
     # alignAndFocusArgs['GroupFilename'] don't use
@@ -391,6 +395,7 @@ def main(config=None):
         alignAndFocusArgs.update(otherArgs)
 
     print(alignAndFocusArgs)
+
     # Setup grouping
     output_grouping = False
     grp_wksp = "wksp_output_group"
@@ -418,6 +423,14 @@ def main(config=None):
                                 OutputWorkspace=grp_wksp)
         alignAndFocusArgs['GroupingWorkspace'] = grp_wksp
 
+    loadKwargs['AlignAndFocusArgs'] = alignAndFocusArgs
+
+    # 2. Get any other additional arguments passed
+    if "AdditionalOptions" in config:
+        additionalOpts = config["AddtionalOptions"]
+        if "CorrelationChopper" in additionalOpts:
+            loadKwargs['CorrelationChopper'] = additionalOpts['CorrelationChopper']
+
     # TODO take out the RecalculatePCharge in the future once tested
     # Load Sample
     print("#-----------------------------------#")
@@ -429,7 +442,7 @@ def main(config=None):
         sam_geometry,
         sam_material,
         sam_mass_density,
-        **alignAndFocusArgs)
+        **loadKwargs)
     sample_title = "sample_and_container"
     print(os.path.join(OutputDir, sample_title + ".dat"))
     print("HERE:", mtd[sam_wksp].getNumberHistograms())
@@ -453,7 +466,7 @@ def main(config=None):
     print("#-----------------------------------#")
     print("# Sample Container")
     print("#-----------------------------------#")
-    container = load('container', container_scans, **alignAndFocusArgs)
+    container = load('container', container_scans, **loadKwargs)
     save_banks(InputWorkspace=container,
                Filename=nexus_filename,
                Title=container,
@@ -470,7 +483,7 @@ def main(config=None):
         container_bg = load(
             'container_background',
             container_bg,
-            **alignAndFocusArgs)
+            **loadKwargs)
         save_banks(InputWorkspace=container_bg,
                    Filename=nexus_filename,
                    Title=container_bg,
@@ -489,7 +502,7 @@ def main(config=None):
         van_geometry,
         van_material,
         van_mass_density,
-        **alignAndFocusArgs)
+        **loadKwargs)
     vanadium_title = "vanadium_and_background"
 
     save_banks(InputWorkspace=van_wksp,
@@ -517,7 +530,7 @@ def main(config=None):
         print("#-----------------------------------#")
         print("# Vanadium Background")
         print("#-----------------------------------#")
-        van_bg = load('vanadium_background', van_bg_scans, **alignAndFocusArgs)
+        van_bg = load('vanadium_background', van_bg_scans, **loadKwargs)
         vanadium_bg_title = "vanadium_background"
         save_banks(InputWorkspace=van_bg,
                    Filename=nexus_filename,

--- a/mantid_total_scattering.py
+++ b/mantid_total_scattering.py
@@ -385,7 +385,7 @@ def main(config=None):
     # alignAndFocusArgs['Params'] = "0.,0.02,40."
     alignAndFocusArgs['ResampleX'] = -6000
     alignAndFocusArgs['Dspacing'] = False
-    alignAndFocusArgs['PreserveEvents'] = False
+    alignAndFocusArgs['PreserveEvents'] = True
     alignAndFocusArgs['MaxChunkSize'] = 8
     alignAndFocusArgs['CacheDir'] = os.path.abspath(cache_dir)
 
@@ -427,7 +427,7 @@ def main(config=None):
 
     # 2. Get any other additional arguments passed
     if "AdditionalOptions" in config:
-        additionalOpts = config["AddtionalOptions"]
+        additionalOpts = config["AdditionalOptions"]
         if "CorrelationChopper" in additionalOpts:
             loadKwargs['CorrelationChopper'] = additionalOpts['CorrelationChopper']
 


### PR DESCRIPTION
This will do 2 main changes:
 * Refactor the `file_handling.load` so it takes general key word arguments instead of just those specific to `AlignAndFocusPowder` arguments. Now, the `AlignAndFocusArgs` are passed as just one of the key-value entries in the key word argument dictionary for `load`. Tests updated to reflect change.
 * Add the [CorelliCrossCorrelate](http://docs.mantidproject.org/v3.5.1/algorithms/CorelliCrossCorrelate-v1.html) algorithm in the `file_handling.load` workflow to address Issue #17 

This DOES NOT:
 * Add a test to cover this new `CorelliCrossCorrelate` part of the `file_handling.load`. This is due to needing to add Corelli test files (ie shrink a test suite of files that currently exists for silicon, upload to remote test server, add into unit testing here and also a system test for Corelli). This will be addressed in later work.
 * Add an example script for Corelli. Will do once the above bullet is addressed for the tests.