### PR TITLE
Expanding Conda recipes (w/ and w/o framework) + CD

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,80 @@
+
+# Created by https://www.gitignore.io/api/pydev,python,eclipse
+# Edit at https://www.gitignore.io/?templates=pydev,python,eclipse
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+### Eclipse Patch ###
+# Eclipse Core
+.project
+
+# JDT-specific (Eclipse Java Development Tools)
+.classpath
+
+# Annotation Processing
+.apt_generated
+
+.sts4-cache/
+
+### pydev ###
+.pydevproject
+
+### Python ###
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -8,7 +85,6 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-env/
 build/
 develop-eggs/
 dist/
@@ -21,9 +97,12 @@ parts/
 sdist/
 var/
 wheels/
+pip-wheel-metadata/
+share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+MANIFEST
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -38,6 +117,7 @@ pip-delete-this-directory.txt
 # Unit test / coverage reports
 htmlcov/
 .tox/
+.nox/
 .coverage
 .coverage.*
 .cache
@@ -45,6 +125,7 @@ nosetests.xml
 coverage.xml
 *.cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo
@@ -53,6 +134,7 @@ coverage.xml
 # Django stuff:
 *.log
 local_settings.py
+db.sqlite3
 
 # Flask stuff:
 instance/
@@ -70,8 +152,19 @@ target/
 # Jupyter Notebook
 .ipynb_checkpoints
 
+# IPython
+profile_default/
+ipython_config.py
+
 # pyenv
 .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don’t work, or not
+#   install all needed dependencies.
+Pipfile.lock
 
 # celery beat schedule file
 celerybeat-schedule
@@ -79,13 +172,14 @@ celerybeat-schedule
 # SageMath parsed files
 *.sage.py
 
-# dotenv
+# Environments
 .env
-
-# virtualenv
 .venv
+env/
 venv/
 ENV/
+env.bak/
+venv.bak/
 
 # Spyder project settings
 .spyderproject
@@ -99,6 +193,13 @@ ENV/
 
 # mypy
 .mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# End of https://www.gitignore.io/api/pydev,python,eclipse
 
 # Files
 *.dat
@@ -110,3 +211,7 @@ ENV/
 cache/
 output/
 total_scattering/isis/polaris/test_input.json
+
+# conda
+conda_build/
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-
 # Created by https://www.gitignore.io/api/pydev,python,eclipse
 # Edit at https://www.gitignore.io/?templates=pydev,python,eclipse
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,13 @@ matrix:
 
   # Conda w/o mantid-framework
   - os: linux
+    env: TYPE="conda" CONDA=2.7    PKG="mantid-total-scattering-python-wrapper"
+    sudo: required
+  - os: linux
     env: TYPE="conda" CONDA=2.7.14 PKG="mantid-total-scattering-python-wrapper"
     sudo: required
   - os: linux
-    env: TYPE="conda" CONDA=3.6 PKG="mantid-total-scattering-python-wrapper" 
+    env: TYPE="conda" CONDA=3.6    PKG="mantid-total-scattering-python-wrapper"
     sudo: required
 
   # Conda w/ mantid-framework
@@ -28,7 +31,7 @@ matrix:
     env: TYPE="conda" CONDA=2.7.14 PKG="mantid-total-scattering"
     sudo: required
   - os: linux
-    env: TYPE="conda" CONDA=3.6 PKG="mantid-total-scattering" 
+    env: TYPE="conda" CONDA=3.6    PKG="mantid-total-scattering"
     sudo: required
 
   # Since Mantid Framework is prone to seg faults
@@ -37,7 +40,7 @@ matrix:
       env: TYPE="conda" CONDA=2.7.14 PKG="mantid-total-scattering"
       sudo: required
     - os: linux
-      env: TYPE="conda" CONDA=3.6 PKG="mantid-total-scattering"
+      env: TYPE="conda" CONDA=3.6    PKG="mantid-total-scattering"
       sudo: required
 
 before_install:
@@ -85,8 +88,10 @@ script:
 
   - |
     if [[ "${TYPE}" == "conda" ]]; then
-      conda install -c mantid/label/nightly mantid-framework
-      python setup.py test;
+      if [[ "${CONDA}" == 2.7.14 || "${CONDA}" == '3.6' ]]; then
+        conda install -c mantid/label/nightly mantid-framework
+        python setup.py test;
+      fi
     fi
 
 deploy:
@@ -110,4 +115,4 @@ deploy:
    on:
      branch: master
      tags: true
-     condition: $TYPE = conda
+     condition: $TYPE = conda AND ($CONDA='2.7' OR $CONDA='3.6')

--- a/.travis.yml
+++ b/.travis.yml
@@ -100,7 +100,7 @@ deploy:
      tags: true
      branch: master
    password:
-     secure: kqA6ITb6fr+9Q/KBeU/mxa+d319Uwgc9wi8OPsZssvSneQ8vGAIVSSDBeCVbKSXLjXUIKUWYfndOiqT8wCQU+jpY1TZG0Bm0zWGGxBvcUJEnVrB7siWJ6l+MZ4nPXFFMtwhP0KMDtwen0fLnGOLQlNLyz3qb0Lf8NkM1BumXDK7Lc7p/x8ziKHQothL047jx+0PMsydbTdK2gae/ADm6R4z+ZJirv0/yciUQnCwmiXSnYX5UHtkXqP3k21ZtTV3eA9vNvK1HMEti51lFDrgTt5EBOxtX0UIz6YqfCl5ZHyXMS4uCwqL/m7gRPAc1MTmSurZ4JJkvsaVrU3vUdIimlm2EwqH6+yOfjvWlTdwjglkplt4Z95/rN3CLvYIrYq76XsG2yxY8c11+xmpSMo2/6vbRvmKhmbyV6tFeBgq5rflA/xJkM5WqSyMcE0lhk8xc0RL7aAeblyAs9q/hN9BiZIesegE6pd8DWYEGw6cWnwzaflLgze0nJYE5gQ5z5LZJky8/Nxdxumtf9XVS48PenaNIbDLLG1ER2nufHHg3/5Yv+c0TMRWKv6plb4OLj2AIYa2aSedm7YyVhCbVV0/xM0HxZ8fpKxBMDuFuuU1S1YgQkex7cCfj2QW2JBGoX/iAvPz1sZcU7A+VKaKMJyY+SSmQf+Sz3Px3O8CE+9LerV4=
+     secure: ${PYPI_UPLOAD_TOKEN}
 
  # Deploy conda package to Anaconda.org https://anaconda.org/marshallmcdonnell/mantid-total-scattering
  - provider: script

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,113 @@
-sudo: required
-language: python
-python:
-  - '2.7'
+dist: trusty
+language: generic
+
 services:
   - docker
+
+matrix:
+  # Lets build be marked complete if all required matrix is finished
+  # https://docs.travis-ci.com/user/build-matrix/#fast-finishing
+  fast_finish: true
+
+  include:
+  # Docker w/ framework
+  - os: linux
+    env: TYPE="docker"
+    sudo: required
+
+  # Conda w/o mantid-framework
+  - os: linux
+    env: TYPE="conda" CONDA=2.7.14 PKG="mantid-total-scattering-python-wrapper"
+    sudo: required
+  - os: linux
+    env: TYPE="conda" CONDA=3.6 PKG="mantid-total-scattering-python-wrapper" 
+    sudo: required
+
+  # Conda w/ mantid-framework
+  - os: linux
+    env: TYPE="conda" CONDA=2.7.14 PKG="mantid-total-scattering"
+    sudo: required
+  - os: linux
+    env: TYPE="conda" CONDA=3.6 PKG="mantid-total-scattering" 
+    sudo: required
+
+  # Since Mantid Framework is prone to seg faults
+  allow_failures:
+    - os: linux
+      env: TYPE="conda" CONDA=2.7.14 PKG="mantid-total-scattering"
+      sudo: required
+    - os: linux
+      env: TYPE="conda" CONDA=3.6 PKG="mantid-total-scattering"
+      sudo: required
+
 before_install:
-  - docker build -t unit-test-env -f .ci/Dockerfile.nightly_ubuntu16.04 .
-  - test_cmd=`./.ci/construct_test_command.sh`
+  - | 
+    if [[ "${TYPE}" == "docker" ]]; then
+      docker build -t test-env -f .ci/Dockerfile.nightly_ubuntu16.04 .;
+      test_cmd=`./.ci/construct_test_command.sh`;
+    fi
+
+  - |
+    if [[ "${TYPE}" == "conda" ]]; then
+      MINICONDA_URL="https://repo.continuum.io/miniconda";
+      MINICONDA_FILE="Miniconda${CONDA:0:1}-latest-Linux-x86_64.sh";
+      wget "${MINICONDA_URL}/${MINICONDA_FILE}";
+      bash ${MINICONDA_FILE} -b -p $HOME/miniconda;
+      export PATH="$HOME/miniconda/bin:$PATH";
+    fi
+
+
+install:
+  - |
+    if [[ "${TYPE}" == "conda" ]]; then
+      conda config --set always_yes yes --set changeps1 no --set anaconda_upload no;
+      conda config --add channels conda-forge --add channels mantid --add channels mantid/label/nightly;
+      conda update  -q conda;
+      conda info -a
+
+      conda create -q -n ${PKG} python=$CONDA flake8 conda-build conda-verify anaconda-client;
+      source activate ${PKG}
+
+      # Build recipe and install 
+      PKG_PATH="./conda.recipe/${PKG}"
+      conda build ${PKG_PATH}
+      export PKG_FILE=$(conda build ${PKG_PATH} --output)
+      conda install ${PKG_FILE}
+      
+    fi
+
 script:
-  - docker run -t unit-test-env /bin/bash -c "$test_cmd"
-  - python setup.py install
+  - |
+    if [[ "${TYPE}" == "docker" ]]; then
+      docker run -t test-env /bin/bash -c "$test_cmd";
+      sudo python setup.py install;
+    fi
+
+  - |
+    if [[ "${TYPE}" == "conda" ]]; then
+      conda install -c mantid/label/nightly mantid-framework
+      python setup.py test;
+    fi
+
 deploy:
-  skip_cleanup: true
-  skip_existing: true
-  provider: pypi
-  user: mcdonnellmt
-  on:
-    tags: true
-  password:
-    secure: kqA6ITb6fr+9Q/KBeU/mxa+d319Uwgc9wi8OPsZssvSneQ8vGAIVSSDBeCVbKSXLjXUIKUWYfndOiqT8wCQU+jpY1TZG0Bm0zWGGxBvcUJEnVrB7siWJ6l+MZ4nPXFFMtwhP0KMDtwen0fLnGOLQlNLyz3qb0Lf8NkM1BumXDK7Lc7p/x8ziKHQothL047jx+0PMsydbTdK2gae/ADm6R4z+ZJirv0/yciUQnCwmiXSnYX5UHtkXqP3k21ZtTV3eA9vNvK1HMEti51lFDrgTt5EBOxtX0UIz6YqfCl5ZHyXMS4uCwqL/m7gRPAc1MTmSurZ4JJkvsaVrU3vUdIimlm2EwqH6+yOfjvWlTdwjglkplt4Z95/rN3CLvYIrYq76XsG2yxY8c11+xmpSMo2/6vbRvmKhmbyV6tFeBgq5rflA/xJkM5WqSyMcE0lhk8xc0RL7aAeblyAs9q/hN9BiZIesegE6pd8DWYEGw6cWnwzaflLgze0nJYE5gQ5z5LZJky8/Nxdxumtf9XVS48PenaNIbDLLG1ER2nufHHg3/5Yv+c0TMRWKv6plb4OLj2AIYa2aSedm7YyVhCbVV0/xM0HxZ8fpKxBMDuFuuU1S1YgQkex7cCfj2QW2JBGoX/iAvPz1sZcU7A+VKaKMJyY+SSmQf+Sz3Px3O8CE+9LerV4=
+
+ # Deploy pure-python package to PyPI https://pypi.org/project/mantid-total-scattering/
+ - provider: pypi
+   user: mcdonnellmt
+   skip_cleanup: true
+   skip_existing: true
+   on:
+     tags: true
+     branch: master
+   password:
+     secure: kqA6ITb6fr+9Q/KBeU/mxa+d319Uwgc9wi8OPsZssvSneQ8vGAIVSSDBeCVbKSXLjXUIKUWYfndOiqT8wCQU+jpY1TZG0Bm0zWGGxBvcUJEnVrB7siWJ6l+MZ4nPXFFMtwhP0KMDtwen0fLnGOLQlNLyz3qb0Lf8NkM1BumXDK7Lc7p/x8ziKHQothL047jx+0PMsydbTdK2gae/ADm6R4z+ZJirv0/yciUQnCwmiXSnYX5UHtkXqP3k21ZtTV3eA9vNvK1HMEti51lFDrgTt5EBOxtX0UIz6YqfCl5ZHyXMS4uCwqL/m7gRPAc1MTmSurZ4JJkvsaVrU3vUdIimlm2EwqH6+yOfjvWlTdwjglkplt4Z95/rN3CLvYIrYq76XsG2yxY8c11+xmpSMo2/6vbRvmKhmbyV6tFeBgq5rflA/xJkM5WqSyMcE0lhk8xc0RL7aAeblyAs9q/hN9BiZIesegE6pd8DWYEGw6cWnwzaflLgze0nJYE5gQ5z5LZJky8/Nxdxumtf9XVS48PenaNIbDLLG1ER2nufHHg3/5Yv+c0TMRWKv6plb4OLj2AIYa2aSedm7YyVhCbVV0/xM0HxZ8fpKxBMDuFuuU1S1YgQkex7cCfj2QW2JBGoX/iAvPz1sZcU7A+VKaKMJyY+SSmQf+Sz3Px3O8CE+9LerV4=
+
+ # Deploy conda package to Anaconda.org https://anaconda.org/marshallmcdonnell/mantid-total-scattering
+ - provider: script
+   script: cd conda.recipe && chmod +x anaconda_upload.sh && ./anaconda_upload.sh ${PKG_FILE}
+   skip_cleanup: true
+   skip_existing: true
+   on:
+     branch: master
+     tags: true
+     condition: $TYPE = conda

--- a/Pipfile
+++ b/Pipfile
@@ -6,14 +6,14 @@ verify_ssl = true
 [dev-packages]
 
 [packages]
-h5py = "*"
-matplotlib = "*"
-numpy = "*"
-scikit-image = "*"
-scipy = "*"
-six = "*"
-PyYAML = "*"
 mantid-total-scattering = {editable = true,path = "."}
+h5py = "*"
+matplotlib = "<3.0"
+numpy = "*"
+scikit-image = "<0.15"
+scipy = "<1.3"
+six = ">=1.10.0"
+PyYAML = "*"
 versioneer = "*"
 flake8 = "*"
 pytest = "*"

--- a/README.md
+++ b/README.md
@@ -20,6 +20,36 @@ Structure factor S(Q) -> Pair Distribution Function G(r)
 ![alt text](https://raw.githubusercontent.com/marshallmcdonnell/mantid_total_scattering/master/images/sofq_to_gofr.png)
 
 
+## Installation
+
+### Anaconda 
+
+**Setup** 
+Add channels with dependencies, create a conda environment with `python_version` set to either `2.7.14` or `3.6`, and activate the environment
+
+```
+conda config --add channels conda-forge --add channels mantid --add channels mantid/label/nightly
+conda create -n mantidts_env python=${python_version}
+conda activate mantidts_env
+```
+
+**Install**
+```
+conda install -c marshallmcdonnell mantid-total-scattering
+```
+
+**Notes**
+If you have an error (see below for example) related to the `libGL` library, you may not have it installed for the Mantid Framework to work. See instructions [here]() for installing the necessary libraries for different OS
+
+Example error:
+`ImportError: First import of "._api" failed with "libGL.so.1: cannot open shared object file...`
+
+If you have an error that another version of Mantid is installed on the machine and being imported via `PYTHONPATH`, you can use the following as a workaround for CLI tool:
+
+```
+PYTHONPATH="" mantidtotalscattering
+```
+
 ## Getting started for development
 
 Clone the repository to a local directory

--- a/conda.recipe/anaconda_upload.sh
+++ b/conda.recipe/anaconda_upload.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# Input
+if [[ $# -ne 1 ]]
+then
+  echo "Usage: anaconda_upload.sh <full package path>"
+  exit 1
+fi
+
+PKG_PATH=$1
+PKG_FILE=$(basename ${PKG_PATH})
+	
+echo "Uploading ${PKG_PATH} artifact..."
+anaconda -v -t ${CONDA_UPLOAD_TOKEN} upload ${PKG_PATH} --force
+
+echo "Successfully deployed ${PKG_FILE} to Anaconda.org."

--- a/conda.recipe/mantid-total-scattering-python-wrapper/meta.yaml
+++ b/conda.recipe/mantid-total-scattering-python-wrapper/meta.yaml
@@ -1,0 +1,38 @@
+{% set data = load_setup_py_data() %}
+
+package:
+  name: "mantid-total-scattering-python-wrapper"
+  version: "{{ data['version'] }}"
+
+source:
+  path: ../..
+
+build:
+  noarch: python
+  string: py{{py}}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - python
+    - setuptools
+
+  run:
+    - python
+
+test:
+  imports:
+    - total_scattering
+    - total_scattering.file_handling
+    - total_scattering.inelastic
+
+about:
+  home: https://github.com/marshallmcdonnell/mantid_total_scattering
+  license: GPL (version 3)
+  license_family: GPL3
+  license_file: 
+  summary: Mantid Total Scattering Reduction
+
+extra:
+  recipe-maintainers:
+    - marshallmcdonnell

--- a/conda.recipe/mantid-total-scattering/meta.yaml
+++ b/conda.recipe/mantid-total-scattering/meta.yaml
@@ -1,0 +1,44 @@
+{% set data = load_setup_py_data() %}
+
+package:
+  name: "mantid-total-scattering"
+  version: "{{ data['version'] }}"
+
+source:
+  path: ../..
+
+build:
+  string: py{{py}}
+  script: python setup.py install --single-version-externally-managed --record=record.txt
+
+requirements:
+  build:
+    - mantid-framework=4
+    - python
+    - setuptools
+
+  run:
+    - mantid-framework=4
+    - python
+
+test:
+  imports:
+    - total_scattering
+    - total_scattering.file_handling
+    - total_scattering.file_handling.load
+    - total_scattering.file_handling.save
+    - total_scattering.inelastic
+    - total_scattering.inelastic.placzek
+    - total_scattering.reduction
+    - total_scattering.reduction.total_scattering_reduction
+
+about:
+  home: https://github.com/marshallmcdonnell/mantid_total_scattering
+  license: GPL (version 3)
+  license_family: GPL3
+  license_file: 
+  summary: Mantid Total Scattering Reduction
+
+extra:
+  recipe-maintainers:
+    - marshallmcdonnell

--- a/setup.py
+++ b/setup.py
@@ -13,19 +13,14 @@ setup(name='mantid_total_scattering',
       description='Mantid Total Scattering Reduction',
       long_description_content_type="text/markdown",
       license='GPL License (version 3)',
-      scripts=['bin/mantidtotalscattering'],
+      entry_points = {
+        'console_scripts': [
+            "mantidtotalscattering = total_scattering.cli:main"
+        ]
+      },
       packages=find_packages(),
       # package_data={'': ['*.ui', '*.png', '*.qrc', '*.json']},
       include_package_data=True,
-      install_requires=[
-        "h5py",
-        "matplotlib<3.0",
-        "networkx==2.2",
-        "numpy",
-        "scikit-image<0.15",
-        "scipy",
-        "six",
-        "pyyaml",
-      ],
-      test_suite='tests'
+      test_suite='tests',
+      tests_require=['pytest']
       )

--- a/total_scattering/cli.py
+++ b/total_scattering/cli.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python
 from __future__ import (absolute_import, division, print_function)
 
 import json

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -8,21 +8,37 @@ from scipy.constants import Avogadro
 
 from mantid import mtd
 from mantid.simpleapi import \
-    CreateEmptyTableWorkspace, Load, GenerateEventsFilter, \
-    LoadDetectorsGroupingFile, LoadDiffCal, \
-    CreateGroupingWorkspace, GroupWorkspaces, \
-    PDDetermineCharacterizations, PropertyManagerDataService, \
-    CloneWorkspace, ConvertUnits, SetSample, Rebin, CompressEvents, \
-    Minus, Divide, SetUncertainties, ConvertToHistogram,\
-    ConvertToDistribution, StripVanadiumPeaks, FFTSmooth, \
-    CarpenterSampleCorrection, MayersSampleCorrection, \
-    CropWorkspaceRagged
+    CarpenterSampleCorrection, \
+    CloneWorkspace, \
+    CompressEvents, \
+    ConvertToDistribution, \
+    ConvertToHistogram,\
+    ConvertUnits, \
+    CreateEmptyTableWorkspace, \
+    CreateGroupingWorkspace, \
+    CropWorkspaceRagged, \
+    Divide, \
+    FFTSmooth, \
+    GenerateEventsFilter, \
+    GroupWorkspaces, \
+    Load, \
+    LoadDetectorsGroupingFile, \
+    LoadDiffCal, \
+    MayersSampleCorrection, \
+    Minus, \
+    PDDetermineCharacterizations, \
+    PropertyManagerDataService, \
+    Rebin, \
+    SetSample, \
+    SetUncertainties, \
+    StripVanadiumPeaks
 
 from total_scattering.file_handling.load import load
 from total_scattering.file_handling.save import save_banks
 from total_scattering.inelastic.placzek import \
-    GetIncidentSpectrumFromMonitor, FitIncidentSpectrum, \
-    CalculatePlaczekSelfScattering
+    CalculatePlaczekSelfScattering, \
+    FitIncidentSpectrum, \
+    GetIncidentSpectrumFromMonitor
 
 # Utilities
 


### PR DESCRIPTION
This adds recipes for both the w/ framework (`mantid-total-scattering) and w/o framework (`mantid-total-scattering-python-wrapper`) conda recipes. 

Also, the Travis CI is updated to allow for automated deployment of the packages with tagged commits on `master`. 

Added `installation` section for conda in README. **Refer to these instructions for testing**

Finally, there is import testing in the recipes to make sure packages work.

This will close #38, #39, and #40 

Conda packages:
https://anaconda.org/marshallmcdonnell/mantid-total-scattering
https://anaconda.org/marshallmcdonnell/mantid-total-scattering-python-wrapper

To verify that deployment works, see this build:
https://travis-ci.org/marshallmcdonnell/mantid_total_scattering/builds/529856458

To verify deployment will not happen on non-tagged commit on non-master branch, see this (latest) build:
https://travis-ci.org/marshallmcdonnell/mantid_total_scattering/builds/529911561
