### PR TITLE
Adds flexibility to input for normaliziation section and testing

### DIFF
--- a/.ci/Dockerfile.nightly_ubuntu16.04_python3
+++ b/.ci/Dockerfile.nightly_ubuntu16.04_python3
@@ -1,10 +1,6 @@
 # Install mantid image
 FROM mantidproject/mantid:nightly_ubuntu16.04_python3
 
-
-# Copy git content from current branch
-COPY . /root/mantid_total_scattering
-
 # Add Mantid to python path
 ENV MANTIDPATH         /opt/mantidnightly/bin
 ENV TSREPO             /root/mantid_total_scattering
@@ -22,6 +18,9 @@ COPY ./tests/data/POLARIS9fbf7121b4274c833043ae8933ec643ff7b9313d.vtp /root/.man
 
 # Hack for seg fault when DownloadInstrument gets called inside container from "import mantid.simpleapi"
 RUN echo "UpdateInstrumentDefinitions.OnStartup = 0" > /root/.mantid/Mantid.user.properties
+
+# Copy git content from current branch
+COPY . /root/mantid_total_scattering
 
 # Move to work directory
 WORKDIR $TSREPO

--- a/.ci/setup_ci_container_locally.sh
+++ b/.ci/setup_ci_container_locally.sh
@@ -7,11 +7,11 @@
 #   . .ci/setup_ci_container_locally.sh
 
 
-CONDA=3.6
-PKG="mantid-total-scattering-wrapper"
+CONDA=2.7
+PKG="mantid-total-scattering-python-wrapper"
 
 apt update -y 
-apt install wget bzip2 vim -y
+apt install wget bzip2 vim freeglut3-dev libglu1-mesa -y
 
 MINICONDA_URL="https://repo.continuum.io/miniconda"
 MINICONDA_FILE="Miniconda${CONDA:0:1}-latest-Linux-x86_64.sh"
@@ -20,10 +20,11 @@ bash ${MINICONDA_FILE} -b -p $HOME/miniconda
 export PATH="$HOME/miniconda/bin:$PATH"
 
 conda config --set always_yes yes --set changeps1 no --set anaconda_upload no;
-conda config --add channels conda-forge --add channels mantid --add channels mantid/label/nightly;
+conda config --add channels conda-forge --add channels mantid;
 conda update  -q conda;
 conda info -a;
-conda create -q -n ${PKG} python=${CONDA} flake8 conda-build=3.17 conda-verify anaconda-client;
+
+conda create -q -n ${PKG} python=${CONDA} flake8 conda-build=3.17 conda-verify anaconda-client pytest;
 source activate ${PKG};
 
 # Build recipe and install 
@@ -32,4 +33,8 @@ conda build ${PKG_PATH};
 export PKG_FILE=$(conda build ${PKG_PATH} --output);
 conda install ${PKG_FILE};
 
+cd $HOME
 conda install -c mantid/label/nightly mantid-framework=4 python=${CONDA};
+which python
+python -V
+python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ matrix:
 before_install:
   - | 
     if [[ "${TYPE}" == "docker" ]]; then
-      docker build -t test-env -f .ci/Dockerfile.nightly_ubuntu16.04 .;
+      docker build -t test-env -f .ci/Dockerfile.nightly_ubuntu16.04_python3 .;
       test_cmd=`./.ci/construct_test_command.sh`;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,15 +20,12 @@ matrix:
     env: TYPE="conda" CONDA=2.7    PKG="mantid-total-scattering-python-wrapper"
     sudo: required
   - os: linux
-    env: TYPE="conda" CONDA=2.7.14 PKG="mantid-total-scattering-python-wrapper"
-    sudo: required
-  - os: linux
     env: TYPE="conda" CONDA=3.6    PKG="mantid-total-scattering-python-wrapper"
     sudo: required
 
   # Conda w/ mantid-framework
   - os: linux
-    env: TYPE="conda" CONDA=2.7.14 PKG="mantid-total-scattering"
+    env: TYPE="conda" CONDA=2.7 PKG="mantid-total-scattering"
     sudo: required
   - os: linux
     env: TYPE="conda" CONDA=3.6    PKG="mantid-total-scattering"
@@ -37,7 +34,7 @@ matrix:
   # Since Mantid Framework is prone to seg faults
   allow_failures:
     - os: linux
-      env: TYPE="conda" CONDA=2.7.14 PKG="mantid-total-scattering"
+      env: TYPE="conda" CONDA=2.7 PKG="mantid-total-scattering"
       sudo: required
     - os: linux
       env: TYPE="conda" CONDA=3.6    PKG="mantid-total-scattering"
@@ -90,12 +87,8 @@ script:
 
   - |
     if [[ "${TYPE}" == "conda" ]]; then
-      if [[ "${CONDA}" == '2.7.14' || "${CONDA}" == '3.6' ]]; then
-        conda install -c mantid/label/nightly mantid-framework=4
-        which python
-        python -V
-        python setup.py test;
-      fi
+      conda install -c mantid/label/nightly mantid-framework=4
+      python setup.py test;
     fi
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ install:
       conda update  -q conda;
       conda info -a
 
-      conda create -q -n ${PKG} python=$CONDA flake8 conda-build=3.17 conda-verify anaconda-client;
+      conda create -q -n ${PKG} python=$CONDA flake8 conda-build=3.17 conda-verify anaconda-client pytest;
       source activate ${PKG}
 
       # Build recipe and install 

--- a/.travis.yml
+++ b/.travis.yml
@@ -92,6 +92,8 @@ script:
     if [[ "${TYPE}" == "conda" ]]; then
       if [[ "${CONDA}" == '2.7.14' || "${CONDA}" == '3.6' ]]; then
         conda install -c mantid/label/nightly mantid-framework=4
+        which python
+        python -V
         python setup.py test;
       fi
     fi

--- a/README.md
+++ b/README.md
@@ -138,5 +138,5 @@ To build and run the tests via [pytest](https://docs.pytest.org), use:
 To build and run tests via [Docker](https://docs.docker.com/), use:
 
 ```bash
-docker build -t unit-test-env -f .ci/Dockerfile.nightly_ubuntu16.04 . && docker run -t unit-test-env /bin/bash -c "mantidpython -m pytest"
+docker build -t unit-test-env -f .ci/Dockerfile.nightly_ubuntu16.04_python3 . && docker run -t unit-test-env /bin/bash -c "mantidpython -m pytest"
 ```

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,8 @@
 import os
-from total_scattering.utils import ROOT_DIR
+from os.path import abspath, dirname, join
 
 # https://docs.travis-ci.com/user/environment-variables/#default-environment-variables
 IN_TRAVIS = os.getenv('TRAVIS', False)
+ROOT_DIR = abspath(join(dirname(abspath(__file__)), '..'))
 EXAMPLE_DIR = os.path.join(ROOT_DIR, 'examples')
 TEST_DATA_DIR = os.path.join(ROOT_DIR, 'tests', 'data')

--- a/tests/total_scattering/test_utils.py
+++ b/tests/total_scattering/test_utils.py
@@ -81,4 +81,3 @@ class TestUtilsForReduction(unittest.TestCase):
         config = {"BadKey": {"Runs": "10-20"}}
         with self.assertRaises(Exception):
             ts.get_normalization(config)
-        

--- a/tests/total_scattering/test_utils.py
+++ b/tests/total_scattering/test_utils.py
@@ -1,0 +1,13 @@
+import unittest
+import total_scattering.reduction.total_scattering_reduction as ts
+
+
+class TestUtilsForReduction(unittest.TestCase):
+
+    def setUp(self):
+        pass
+
+    def test_one_and_only_one(self):
+        inputList = [True, False, False]
+        output = ts.one_and_only_one(inputList)
+        self.assertTrue(output)

--- a/tests/total_scattering/test_utils.py
+++ b/tests/total_scattering/test_utils.py
@@ -38,7 +38,7 @@ class TestUtilsForReduction(unittest.TestCase):
         keys = ["Vanadium", "Normalization", "Normalisation"]
         dictionary = {"Sample": True}
         with self.assertRaises(Exception):
-            match_value = ts.extract_key_match_from_dict(keys, dictionary)
+            ts.extract_key_match_from_dict(keys, dictionary)
 
     def test_get_sample_when_match(self):
         """ Test extracting sample info from config
@@ -52,7 +52,7 @@ class TestUtilsForReduction(unittest.TestCase):
         """
         config = {"BadKey": {"Runs": "10-20"}}
         with self.assertRaises(Exception):
-            sample_value = ts.get_sample(config)
+            ts.get_sample(config)
 
     def test_get_normalization_when_match_for_vanadium(self):
         """ Test extracting vanadium info from config
@@ -80,5 +80,5 @@ class TestUtilsForReduction(unittest.TestCase):
         """
         config = {"BadKey": {"Runs": "10-20"}}
         with self.assertRaises(Exception):
-            norm_value = ts.get_normalization(config)
+            ts.get_normalization(config)
         

--- a/tests/total_scattering/test_utils.py
+++ b/tests/total_scattering/test_utils.py
@@ -39,4 +39,46 @@ class TestUtilsForReduction(unittest.TestCase):
         dictionary = {"Sample": True}
         with self.assertRaises(Exception):
             match_value = ts.extract_key_match_from_dict(keys, dictionary)
+
+    def test_get_sample_when_match(self):
+        """ Test extracting sample info from config
+        """
+        config = {"Sample": {"Runs": "10-20"}}
+        sample_value = ts.get_sample(config)
+        self.assertEqual(config["Sample"], sample_value)
+
+    def test_get_sample_raise_error_when_no_match(self):
+        """ Test that we raise an error when no Sample key found
+        """
+        config = {"BadKey": {"Runs": "10-20"}}
+        with self.assertRaises(Exception):
+            sample_value = ts.get_sample(config)
+
+    def test_get_normalization_when_match_for_vanadium(self):
+        """ Test extracting vanadium info from config
+        """
+        config = {"Vanadium": {"Runs": "10-20"}}
+        norm_value = ts.get_normalization(config)
+        self.assertEqual(config["Vanadium"], norm_value)
+
+    def test_get_normalization_when_match_for_normalization(self):
+        """ Test extracting normalization info from config
+        """
+        config = {"Normalization": {"Runs": "10-20"}}
+        norm_value = ts.get_normalization(config)
+        self.assertEqual(config["Normalization"], norm_value)
+
+    def test_get_normalization_when_match_for_normalisation(self):
+        """ Test extracting normalisation info from config
+        """
+        config = {"Normalisation": {"Runs": "10-20"}}
+        norm_value = ts.get_normalization(config)
+        self.assertEqual(config["Normalisation"], norm_value)
+
+    def test_get_normalization_raise_error_when_no_match(self):
+        """ Test that we raise an error when no normalization keys found
+        """
+        config = {"BadKey": {"Runs": "10-20"}}
+        with self.assertRaises(Exception):
+            norm_value = ts.get_normalization(config)
         

--- a/tests/total_scattering/test_utils.py
+++ b/tests/total_scattering/test_utils.py
@@ -8,6 +8,35 @@ class TestUtilsForReduction(unittest.TestCase):
         pass
 
     def test_one_and_only_one(self):
+        """ Test for the one and only one true value utility function
+        """
         inputList = [True, False, False]
         output = ts.one_and_only_one(inputList)
         self.assertTrue(output)
+
+    def test_find_key_match_in_dict(self):
+        """ Test for using list of keys to get back value of
+        one and only one matching key from dict
+        """
+        keys = ["Vanadium", "Normalization", "Normalisation"]
+        dictionary = {"Normalization": True}
+        match_value = ts.find_key_match_in_dict(keys, dictionary)
+        self.assertTrue(match_value)
+
+    def test_extract_key_match_from_dict_for_match(self):
+        """ Test for using list of keys to get back value of
+        one and only one matching key from dict with error handling wrapper
+        """
+        keys = ["Vanadium", "Normalization", "Normalisation"]
+        dictionary = {"Normalization": True}
+        match_value = ts.extract_key_match_from_dict(keys, dictionary)
+        self.assertTrue(match_value)
+
+    def test_extract_key_match_from_dict_raise_error_when_no_match(self):
+        """ Test that we raise an error when no keys found in dict
+        """
+        keys = ["Vanadium", "Normalization", "Normalisation"]
+        dictionary = {"Sample": True}
+        with self.assertRaises(Exception):
+            match_value = ts.extract_key_match_from_dict(keys, dictionary)
+        

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -310,22 +310,22 @@ def find_key_match_in_dict(keys, dictionary):
     return None
 
 
-def extract_from_dict_using_keys(dictionary, keys):
+def extract_key_match_from_dict(keys, dictionary):
     """ Convienence function for extraction of one key from dictionary
 
-    :param dictionary: Dictionary to check
-    "type dictionary: dict
     :param keys: Keys to check against dictionary
     :type keys: list
+    :param dictionary: Dictionary to check
+    "type dictionary: dict
 
-    :return: The exctracted value for normalization in the input
+    :return: The exctracted value
     :rtype: any
     """
     out = find_key_match_in_dict(keys, dictionary)
     if out:
         return out
     else:
-        e = "No normalization section found. Valid keys are {}".format(keys)
+        e = "No matching key found. Valid keys are {}".format(keys)
         raise Exception(e)
 
 
@@ -339,7 +339,7 @@ def get_sample(config):
     :rtype: any
     """
     keys = ["Sample"]
-    out = extract_from_dict_using_keys(config, keys)
+    out = extract_key_match_from_dict(keys, config)
     return out
 
 
@@ -353,7 +353,7 @@ def get_normalization(config):
     :rtype: any
     """
     keys = ["Normalization", "Normalisation", "Vanadium"]
-    out = extract_from_dict_using_keys(config, keys)
+    out = extract_key_match_from_dict(keys, config)
     return out
 
 

--- a/total_scattering/reduction/total_scattering_reduction.py
+++ b/total_scattering/reduction/total_scattering_reduction.py
@@ -266,20 +266,111 @@ def SetInelasticCorrection(inelastic_dict):
     return inelastic_settings
 
 
+def one_and_only_one(iterable):
+    """Determine if iterable (ie list) has one and only one `True` value
+
+    :param iterable: The iterable to check
+    :type iterable: list
+
+    :return: If there is one and only one True
+    :rtype: bool
+    """
+    try:
+        iterator = iter(iterable)
+        has_true = any(iterator)
+        has_another_true = any(iterator)
+        return has_true and not has_another_true
+    except Exception as e:
+        print(e)
+        raise
+
+
+def find_key_match_in_dict(keys, dictionary):
+    """ Check if one and only one of the keys is in the dictionary
+    and return its value
+
+    :param key: Keys we will check for in dictionary
+    :type key: str
+    :param dictionary: Dictionary to check
+    :type dictionary: dict
+
+    :return: Either the value in dictionary for the key or None if not found
+    :rtype: value in dict or None
+    """
+    # Get the boolean for each key if it exists in the dictionary
+    keys_exist_in_dict = map(lambda key: key in dictionary, keys)
+
+    # If only one exists, return the match, else raise exception
+    if one_and_only_one(keys_exist_in_dict):
+        for key in keys:
+            if key in dictionary:
+                return dictionary[key]
+
+    # None of the keys in the dictionary, return None
+    return None
+
+
+def extract_from_dict_using_keys(dictionary, keys):
+    """ Convienence function for extraction of one key from dictionary
+
+    :param dictionary: Dictionary to check
+    "type dictionary: dict
+    :param keys: Keys to check against dictionary
+    :type keys: list
+
+    :return: The exctracted value for normalization in the input
+    :rtype: any
+    """
+    out = find_key_match_in_dict(keys, dictionary)
+    if out:
+        return out
+    else:
+        e = "No normalization section found. Valid keys are {}".format(keys)
+        raise Exception(e)
+
+
+def get_sample(config):
+    """ Extract the sample section from JSON input
+
+    :param config: JSON input for reduction
+    :type config: dict
+
+    :return: The exctracted value for sample in the input
+    :rtype: any
+    """
+    keys = ["Sample"]
+    out = extract_from_dict_using_keys(config, keys)
+    return out
+
+
+def get_normalization(config):
+    """ Extract the normalization section from JSON input
+
+    :param config: JSON input for reduction
+    :type config: dict
+
+    :return: The exctracted value for normalization in the input
+    :rtype: any
+    """
+    keys = ["Normalization", "Normalisation", "Vanadium"]
+    out = extract_from_dict_using_keys(config, keys)
+    return out
+
+
 def TotalScatteringReduction(config=None):
     facility = config['Facility']
     title = config['Title']
     instr = config['Instrument']
 
     # Get sample info
-    sample = config['Sample']
+    sample = get_sample(config)
     sam_mass_density = sample.get('MassDensity', None)
     sam_packing_fraction = sample.get('PackingFraction', None)
     sam_geometry = sample.get('Geometry', None)
     sam_material = sample.get('Material', None)
 
     # Get normalization info
-    van = config['Normalization']
+    van = get_normalization(config)
     van_mass_density = van.get('MassDensity', None)
     van_packing_fraction = van.get('PackingFraction', 1.0)
     van_geometry = van.get('Geometry', None)


### PR DESCRIPTION
Fixes #45 

Adds flexibility to input for normalization.
Options:
 - `Vanadium`
 - `Normalization`
 - `Normalisation`

Adds utitiliy functions to `total_scattering.reduction.total_scattering_reduction` to facilitate this flexibility

Adds necessary tests

Updates README to use Python 3 Dockerfile and added the python 3 dockerfile