### PR TITLE
Pins conda==4.7.5 since 4.7.7 is broken

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,11 @@ install:
     if [[ "${TYPE}" == "conda" ]]; then
       conda config --set always_yes yes --set changeps1 no --set anaconda_upload no;
       conda config --add channels conda-forge --add channels mantid;
-      conda update  -q conda;
+      # conda update  -q conda
+      # pinned because 4.7.7 is broken when using `conda update -q conda`
+      # can remove this if this issue is closed:
+      # - https://github.com/conda/conda/issues/8934
+      conda install  -q conda==4.7.5;
       conda info -a
 
       conda create -q -n ${PKG} python=$CONDA flake8 conda-build=3.17 conda-verify anaconda-client pytest;

--- a/.travis.yml
+++ b/.travis.yml
@@ -63,7 +63,7 @@ install:
   - |
     if [[ "${TYPE}" == "conda" ]]; then
       conda config --set always_yes yes --set changeps1 no --set anaconda_upload no;
-      conda config --add channels conda-forge --add channels mantid;
+      conda config --add channels conda-forge --add channels mantid --add channels mantid/label/nightly;
       # conda update  -q conda
       # pinned because 4.7.7 is broken when using `conda update -q conda`
       # can remove this if this issue is closed:


### PR DESCRIPTION
The issue is reported here. PR is in at time of this writing. Once this is fixed, should unpin this version of conda:

https://github.com/conda/conda/issues/8934