### PR TITLE
Fix for still broken coverage report

### DIFF
--- a/.ci/construct_test_command.sh
+++ b/.ci/construct_test_command.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 token=d9212b19-6bbd-4466-8f45-18414480f879
-coverage_bin="which $(coverage)"
+coverage_bin="/usr/local/bin/coverage"
 cd_repo="cd /root/mantid_total_scattering"
 ci_env="bash <(curl -s https://codecov.io/env)"
 run_main="mantidpython --classic ./total_scattering/cli.py --help"


### PR DESCRIPTION
The `which $(coverage)` did not work so just added the full path to `coverage` in the construct test script.